### PR TITLE
pep 420 native namespace

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-4.1 (unreleased)
+5.0 (unreleased)
 ----------------
 
 - Nothing changed yet.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 5.0 (unreleased)
 ----------------
 
-- Replace ``pkg_resources`` namespace with PEP 420 native namespace.
+- Replace the ``pkg_resources`` namespace with PEP 420 native namespace.
 
 
 4.0 (2024-05-21)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 5.0 (unreleased)
 ----------------
 
-- Replace the ``pkg_resources`` namespace with PEP 420 native namespace.
+- Replace ``pkg_resources`` namespace with PEP 420 native namespace.
 
 
 4.0 (2024-05-21)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 5.0 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Replace ``pkg_resources`` namespace with PEP 420 native namespace.
 
 
 4.0 (2024-05-21)

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name='gocept.testing',
-    version='4.1.dev0',
+    version='5.0.dev0',
     author='minddistrict <mail at minddistrict dot com>',
     author_email='mail@minddistrict.com',
     url='https://github.com/minddistrict/gocept.testing',

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,3 @@
-from setuptools import find_packages
 from setuptools import setup
 
 
@@ -35,13 +34,10 @@ A collection of test helpers, additional assertions, and the like.""",
     ],
     long_description=(open('README.rst').read() + '\n\n' +
                       open('CHANGES.rst').read()),
-    packages=find_packages('src'),
-    package_dir={'': 'src'},
     include_package_data=True,
     zip_safe=False,
     license='MIT',
     keywords="testing unittest assertions",
-    namespace_packages=['gocept'],
     python_requires='>=3.9',
     install_requires=[
         'setuptools',

--- a/src/gocept/__init__.py
+++ b/src/gocept/__init__.py
@@ -1,1 +1,0 @@
-__import__('pkg_resources').declare_namespace(__name__)  # pragma: no cover


### PR DESCRIPTION
- **Bumped version for breaking release.**
- **Replace ``pkg_resources`` namespace with PEP 420 native namespace.**
- **Switch to PEP 420 native namespace.**
